### PR TITLE
chore: added dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle" # See documentation for possible values
+    directory: "/" # Location of package manifests XY
+    target-branch: "develop"
+    schedule:
+      timezone: "Europe/Berlin"
+      time: "07:00"
+      interval: "daily"


### PR DESCRIPTION
This pull request adds a new Dependabot configuration file to enable automated dependency updates for the repository.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R14): Introduced a configuration file to set up daily dependency updates for the Gradle package ecosystem. Updates will target the `develop` branch and follow a schedule at 07:00 in the Europe/Berlin timezone.