### PR TITLE
1.21.8 update

### DIFF
--- a/common/src/main/java/net/eternalempires/mod/common/Constants.java
+++ b/common/src/main/java/net/eternalempires/mod/common/Constants.java
@@ -14,5 +14,5 @@ public class Constants {
             "beta.eternalempires.dev"
     );
 
-    public static final @NotNull String VERSION = SharedConstants.getCurrentVersion().getName();
+    public static final @NotNull String VERSION = SharedConstants.getCurrentVersion().name();
 }

--- a/common/src/main/java/net/eternalempires/mod/common/network/UpdateDiscordRpcPayload.java
+++ b/common/src/main/java/net/eternalempires/mod/common/network/UpdateDiscordRpcPayload.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import lombok.extern.slf4j.Slf4j;
 import net.eternalempires.mod.common.client.DiscordRPCManager;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import org.jetbrains.annotations.NotNull;
@@ -20,6 +21,16 @@ public class UpdateDiscordRpcPayload extends AbstractEternalEmpiresPayload {
 
                         return new UpdateDiscordRpcPayload(data);
                     });
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, UpdateDiscordRpcPayload> FORGE_CODEC =
+            StreamCodec.of(
+                    (buf, packet) -> buf.writeBytes(packet.data),
+                    buf -> {
+                        byte[] data = new byte[buf.readableBytes()];
+                        buf.readBytes(data);
+                        return new UpdateDiscordRpcPayload(data);
+                    }
+            );
 
     public static final StreamCodec<FriendlyByteBuf, UpdateDiscordRpcPayload> FABRIC_CODEC =
             StreamCodec.of((buf, value) -> buf.writeBytes(value.data),

--- a/forge/src/main/java/net/eternalempires/mod/forge/EternalEmpiresForge.java
+++ b/forge/src/main/java/net/eternalempires/mod/forge/EternalEmpiresForge.java
@@ -5,7 +5,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.eternalempires.mod.common.Constants;

--- a/forge/src/main/java/net/eternalempires/mod/forge/network/PacketHandler.java
+++ b/forge/src/main/java/net/eternalempires/mod/forge/network/PacketHandler.java
@@ -4,26 +4,21 @@ import net.eternalempires.mod.common.Constants;
 import net.eternalempires.mod.common.network.UpdateDiscordRpcPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.network.ChannelBuilder;
-import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.SimpleChannel;
 
 public class PacketHandler {
-
-    private static final SimpleChannel INSTANCE = ChannelBuilder.named(
+    private static final SimpleChannel UPDATE_RPC = ChannelBuilder.named(
                     ResourceLocation.fromNamespaceAndPath(Constants.MOD_ID, "mod"))
             .serverAcceptedVersions((_, _) -> true)
             .clientAcceptedVersions((_, _) -> true)
             .networkProtocolVersion(1)
-            .simpleChannel();
+            .simpleChannel()
+            .play()
+            .clientbound()
+            .add(UpdateDiscordRpcPayload.class, UpdateDiscordRpcPayload.FORGE_CODEC, (packet, _) -> {
+                packet.handlePayload();
+            })
+            .build();
 
-    //todo: SimpleChannel#messageBuilder is deprecated
-    public static void register() {
-        INSTANCE.messageBuilder(UpdateDiscordRpcPayload.class, NetworkDirection.PLAY_TO_CLIENT)
-                .encoder(UpdateDiscordRpcPayload::encode)
-                .decoder(UpdateDiscordRpcPayload::new)
-                .consumerMainThread((packet, _) -> {
-                    packet.handlePayload(); // No need for Forge context!
-                })
-                .add();
-    }
+    public static void register() {}
 }

--- a/forge/src/main/java/net/eternalempires/mod/forge/network/PacketHandler.java
+++ b/forge/src/main/java/net/eternalempires/mod/forge/network/PacketHandler.java
@@ -20,5 +20,5 @@ public class PacketHandler {
             })
             .build();
 
-    public static void register() {}
+    public static void register() {}  // method is called in Forge Main class to register UPDATE_RPC above
 }

--- a/forge/src/main/java/net/eternalempires/mod/forge/network/PacketHandler.java
+++ b/forge/src/main/java/net/eternalempires/mod/forge/network/PacketHandler.java
@@ -20,5 +20,7 @@ public class PacketHandler {
             })
             .build();
 
-    public static void register() {}  // method is called in Forge Main class to register UPDATE_RPC above
+    public static void register() {
+        // method is called in Forge Main class to register UPDATE_RPC above
+    }
 }

--- a/neoforge/src/main/java/net/eternalempires/mod/neoforge/EternalEmpiresNeoForge.java
+++ b/neoforge/src/main/java/net/eternalempires/mod/neoforge/EternalEmpiresNeoForge.java
@@ -9,7 +9,6 @@ import net.eternalempires.mod.common.network.UpdateDiscordRpcPayload;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ServerData;
 import net.neoforged.api.distmarker.Dist;
-import net.neoforged.bus.EventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;

--- a/neoforge/src/main/java/net/eternalempires/mod/neoforge/EternalEmpiresNeoForge.java
+++ b/neoforge/src/main/java/net/eternalempires/mod/neoforge/EternalEmpiresNeoForge.java
@@ -9,6 +9,7 @@ import net.eternalempires.mod.common.network.UpdateDiscordRpcPayload;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ServerData;
 import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.EventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
@@ -25,7 +26,7 @@ public class EternalEmpiresNeoForge {
         EternalEmpires.init();
     }
 
-    @EventBusSubscriber(modid = Constants.MOD_ID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+    @EventBusSubscriber(modid = Constants.MOD_ID, value = Dist.CLIENT)
     public static class ClientModEvents {
 
         @SubscribeEvent
@@ -50,7 +51,7 @@ public class EternalEmpiresNeoForge {
         }
     }
 
-    @EventBusSubscriber(modid = Constants.MOD_ID, bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
+    @EventBusSubscriber(modid = Constants.MOD_ID, value = Dist.CLIENT)
     public static class ServerConnectionHandler {
 
         private static String lastServerIP = null;

--- a/versionProperties/1.21.5.properties
+++ b/versionProperties/1.21.5.properties
@@ -1,18 +1,18 @@
 # General Properties
 java_version=21
-minecraft_version=1.21.5
-compatible_mc_versions=["1.21.5"]
+minecraft_version=1.21.8
+compatible_mc_versions=["1.21.8"]
 
 # Fabric-specific Properties
 fabric_loader=0.16.14
-fabric_api_version=0.126.0+1.21.5
+fabric_api_version=0.129.0+1.21.8
 
 # Forge-specific Properties
-forge_loader=55.0.22
+forge_loader=58.0.0
 
 # NeoForge-specific Properties
 ## Unimined wants the last version number, for example, 21.5.75 -> 75
-neoforge_loader=75
+neoforge_loader=5-beta
 
 # Selected loaders
 builds_for=fabric,forge,neoforge


### PR DESCRIPTION
This pull request introduces several updates across the codebase to improve compatibility, streamline event handling, and enhance network communication. It also updates version properties to align with the latest Minecraft version. Below are the most significant changes grouped by theme:

### Compatibility Updates:
- Updated `VERSION` in `Constants.java` to use `.name()` instead of `.getName()` for compatibility with newer APIs. (`[common/src/main/java/net/eternalempires/mod/common/Constants.javaL17-R17](diffhunk://#diff-5d63595726a1afa3e331accdae76144159aa22e38aa69a3fc16087a779d5b77fL17-R17)`)
- Updated `versionProperties/1.21.5.properties` to reflect the new Minecraft version (`1.21.8`) and corresponding loader versions for Fabric, Forge, and NeoForge. (`[versionProperties/1.21.5.propertiesL3-R15](diffhunk://#diff-d7010b5af4b7f069abf90bd2534cccb84e57573fd6c2ec029f611d3b13d8645dL3-R15)`)

### Network Communication Enhancements:
- Introduced `FORGE_CODEC` in `UpdateDiscordRpcPayload.java` to support Forge-specific payload encoding and decoding. (`[common/src/main/java/net/eternalempires/mod/common/network/UpdateDiscordRpcPayload.javaR25-R34](diffhunk://#diff-736cb6e07df833cfb7342de258f6ba53a3f17230e70cea5c8df54a4f25daee9aR25-R34)`)
- Refactored `PacketHandler.java` to replace deprecated methods and improve Forge clientbound payload handling using `FORGE_CODEC`. (`[forge/src/main/java/net/eternalempires/mod/forge/network/PacketHandler.javaL7-R23](diffhunk://#diff-d813f81470de494bd89428b61335ac37e4087e7e1ccd1a233f9045b8e7b0353cL7-R23)`)

### Event Handling Improvements:
- Replaced `@SubscribeEvent` annotation in Forge-specific event handling with `@listener.SubscribeEvent` for better integration with updated Forge APIs. (`[forge/src/main/java/net/eternalempires/mod/forge/EternalEmpiresForge.javaL8-R8](diffhunk://#diff-2c31b5a699a12bb4fd8dbe43fe89519cea99f77a771ab1d0cc14e6f89989939dL8-R8)`)
- Removed `bus` parameter from `@EventBusSubscriber` annotations in NeoForge event handlers to simplify event subscription logic. (`[[1]](diffhunk://#diff-8d217ef052cc53f42cb88636667f606959dac3291d3a54f46e15166d1ad30ad9L28-R29)`, `[[2]](diffhunk://#diff-8d217ef052cc53f42cb88636667f606959dac3291d3a54f46e15166d1ad30ad9L53-R54)`)